### PR TITLE
WIP: Update dependencies for security fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     RedCloth (4.2.9)
     abstract (1.0.0)
-    actionpack (3.0.12)
-      activemodel (= 3.0.12)
-      activesupport (= 3.0.12)
+    actionpack (3.0.20)
+      activemodel (= 3.0.20)
+      activesupport (= 3.0.20)
       builder (~> 2.1.2)
       erubis (~> 2.6.6)
       i18n (~> 0.5.0)
@@ -13,16 +13,16 @@ GEM
       rack-mount (~> 0.6.14)
       rack-test (~> 0.5.7)
       tzinfo (~> 0.3.23)
-    activemodel (3.0.12)
-      activesupport (= 3.0.12)
+    activemodel (3.0.20)
+      activesupport (= 3.0.20)
       builder (~> 2.1.2)
       i18n (~> 0.5.0)
-    activesupport (3.0.12)
+    activesupport (3.0.20)
     builder (2.1.2)
-    daemons (1.1.8)
+    daemons (1.2.6)
     erubis (2.6.6)
       abstract (>= 1.0.0)
-    eventmachine (1.0.0.beta.4)
+    eventmachine (1.0.9.1)
     guides (0.7.2)
       RedCloth (~> 4.2.7)
       actionpack (~> 3.0.0)
@@ -32,23 +32,23 @@ GEM
       rack (~> 1.2.1)
       thin (~> 1.2.7)
       thor (~> 0.14.6)
-    i18n (0.5.0)
-    maruku (0.6.0)
+    i18n (0.5.4)
+    maruku (0.6.1)
       syntax (>= 1.0.0)
-    rack (1.2.5)
+    rack (1.2.8)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
     rack-test (0.5.7)
       rack (>= 1.0)
-    rake (0.9.2.2)
-    stringex (1.3.2)
-    syntax (1.0.0)
+    rake (12.3.0)
+    stringex (2.8.2)
+    syntax (1.2.2)
     thin (1.2.11)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     thor (0.14.6)
-    tzinfo (0.3.32)
+    tzinfo (0.3.53)
 
 PLATFORMS
   ruby
@@ -57,3 +57,6 @@ DEPENDENCIES
   guides
   rake
   stringex
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
So I ran `bundle update` but it doesn't update to versions suggested in https://github.com/adcloud/adserver-json-feed/network/dependencies#3195129

Looking at the Gemfile it doesn't specify any versions. How would I make sure to get past `Actionpack ~> 3.2.22.2` like Github security check suggested?